### PR TITLE
BOLT #7 : Receiving node requirements related to timestamp for channel_update message

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -498,8 +498,8 @@ The receiving node:
   `channel_update` for this `short_channel_id` AND for `node_id`:
     - SHOULD ignore the message.
   - otherwise:
-    - if the `timestamp` is equal to the last-received `channel_update`,
-    AND the fields differ (with a valid `signature` for the message):
+    - if the `timestamp` is equal to the last-received `channel_update` for this
+    `short_channel_id` AND `node_id`, AND the fields below `timestamp` differ:
       - MAY blacklist this `node_id`.
       - MAY forget all channels associated with it.
   - if the `timestamp` is unreasonably far in the future:
@@ -523,6 +523,13 @@ either too far in the future or have not been updated in two weeks; so it
 makes sense to have it be a UNIX timestamp (i.e. seconds since UTC
 1970-01-01). This cannot be a hard requirement, however, given the possible case
 of two `channel_update`s within a single second.
+
+It is assumed that more than one `channel_update` message changing the channel 
+parameters in the same second is a DoS attempt, and therefore, the node responsible 
+for signing such messages ought to be blacklisted. However, a node can send a same 
+`channel_update` message with a different signature (changing the nonce in signature 
+signing), and hence fields apart from signature are checked to see if the channel 
+parameters have changed for the same timestamp.
 
 The explicit `option_channel_htlc_max` flag to indicate the presence
 of `htlc_maximum_msat` (rather than having `htlc_maximum_msat` implied


### PR DESCRIPTION
While going through the BOLT #7 I was confused by this receiving node requirement for `channel_update` message: "if the `timestamp` is equal to the last-received `channel_update` AND the fields (other than `signature`) differ: MAY blacklist this `node_id`; MAY forget all channels associated with it." On the outset it might read to "`timestamp` should be same, the `signature` should be same as previous but if the other data is different; then blacklist the `node_id`". However, if `signature` is same as previous update but data is different, then the `signature` would be rendered invalid. And since `signature` check is done prior to the `timestamp` check, this situation of checking may not arise. So this check seems to be redundant. However, Mark H corrected me on stackexchange (https://bitcoin.stackexchange.com/questions/88350/bolt-7-can-receiving-node-requirements-in-channel-update-message-give-rise-to) by saying that a valid signature must be provided for this update and timestamp to go through. This pull slightly corrects the language behind this check and adds a paragraph in the rationale to explain that point.

While creating this pull request, I also noticed a slight typo in the same section. The sentence prior to the one I mentioned above says that if the timestamp is not greater than the previous message, the node should ignore the message. And the second sentence is about comparing if timestamp is equal. But again, the equal to check might not be processed as the message will be discarded if it is not greater. I have changed that to "greater than or equal to".